### PR TITLE
[Clang] Fix parsing of pack-index-specifier with template-id pattern

### DIFF
--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -1147,8 +1147,9 @@ void Parser::AnnotateExistingDecltypeSpecifier(const DeclSpec &DS,
 }
 
 SourceLocation Parser::ParsePackIndexingType(DeclSpec &DS) {
-  assert(Tok.isOneOf(tok::annot_pack_indexing_type, tok::identifier) &&
-         "Expected an identifier");
+  assert(Tok.isOneOf(tok::annot_pack_indexing_type, tok::identifier,
+                     tok::annot_template_id) &&
+         "Expected an identifier or template-id");
 
   TypeResult Type;
   SourceLocation StartLoc;
@@ -1180,15 +1181,41 @@ SourceLocation Parser::ParsePackIndexingType(DeclSpec &DS) {
     return Tok.getEndLoc();
   }
 
-  ParsedType Ty = Actions.getTypeName(*Tok.getIdentifierInfo(),
-                                      Tok.getLocation(), getCurScope());
-  if (!Ty) {
-    DS.SetTypeSpecError();
-    return Tok.getEndLoc();
-  }
-  Type = Ty;
+  if (Tok.is(tok::annot_template_id)) {
+    TemplateIdAnnotation *TemplateId = takeTemplateIdAnnotation(Tok);
+    StartLoc = TemplateId->TemplateNameLoc;
 
-  StartLoc = ConsumeToken();
+    ASTTemplateArgsPtr TemplateArgsPtr(TemplateId->getTemplateArgs(),
+                                       TemplateId->NumArgs);
+    CXXScopeSpec SS;
+    TypeResult Ty =
+        TemplateId->isInvalid()
+            ? TypeError()
+            : Actions.ActOnTemplateIdType(
+                  getCurScope(), ElaboratedTypeKeyword::None,
+                  /*ElaboratedKeywordLoc=*/SourceLocation(), SS,
+                  TemplateId->TemplateKWLoc, TemplateId->Template,
+                  TemplateId->Name, TemplateId->TemplateNameLoc,
+                  TemplateId->LAngleLoc, TemplateArgsPtr, TemplateId->RAngleLoc,
+                  /*IsCtorOrDtorName=*/false, /*IsClassName=*/false,
+                  ImplicitTypenameContext::No);
+
+    if (Ty.isInvalid()) {
+      DS.SetTypeSpecError();
+      return TemplateId->RAngleLoc;
+    }
+    Type = Ty;
+    ConsumeAnnotationToken();
+  } else {
+    ParsedType Ty = Actions.getTypeName(*Tok.getIdentifierInfo(),
+                                        Tok.getLocation(), getCurScope());
+    if (!Ty) {
+      DS.SetTypeSpecError();
+      return Tok.getEndLoc();
+    }
+    Type = Ty;
+    StartLoc = ConsumeToken();
+  }
   EllipsisLoc = ConsumeToken();
   BalancedDelimiterTracker T(*this, tok::l_square);
   T.consumeOpen();

--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -324,6 +324,37 @@ bool Parser::ParseOptionalCXXScopeSpecifier(
       continue;
     }
 
+    // Handle template-id pack-index-specifier
+    if (Tok.is(tok::annot_template_id) && NextToken().is(tok::ellipsis) &&
+        GetLookAheadToken(2).is(tok::l_square) &&
+        !GetLookAheadToken(3).is(tok::r_square)) {
+      SourceLocation Start = Tok.getLocation();
+      DeclSpec DS(AttrFactory);
+      SourceLocation CCLoc;
+      SourceLocation EndLoc = ParsePackIndexingType(DS);
+      if (DS.getTypeSpecType() == DeclSpec::TST_error)
+        return false;
+
+      QualType Pattern = Sema::GetTypeFromParser(DS.getRepAsType());
+      QualType Type =
+          Actions.ActOnPackIndexingType(Pattern, DS.getPackIndexingExpr(),
+                                        DS.getBeginLoc(), DS.getEllipsisLoc());
+
+      if (Type.isNull())
+        return false;
+
+      if (!TryConsumeToken(tok::coloncolon, CCLoc)) {
+        AnnotateExistingIndexedTypeNamePack(ParsedType::make(Type), Start,
+                                            EndLoc);
+        return false;
+      }
+      if (Actions.ActOnCXXNestedNameSpecifierIndexedPack(SS, DS, CCLoc,
+                                                         std::move(Type)))
+        SS.SetInvalid(SourceRange(Start, CCLoc));
+      HasScopeSpecifier = true;
+      continue;
+    }
+
     if (Tok.is(tok::annot_template_id) && NextToken().is(tok::coloncolon)) {
       // We have
       //

--- a/clang/test/Parser/cxx2c-pack-indexing.cpp
+++ b/clang/test/Parser/cxx2c-pack-indexing.cpp
@@ -83,3 +83,30 @@ void foo() {
 }
 
 }
+
+namespace TemplateIdPackIndexing {
+
+template <typename T>
+struct Inner {
+  using type = T;
+  static constexpr int value = 42;
+};
+
+template <template<typename> typename... TT>
+struct Test {
+  using type = TT<int>...[0]::type;
+  static constexpr auto value = TT<int>...[0]::value;
+};
+
+static_assert(Test<Inner>::value == 42);
+
+template <template<typename> typename... TT>
+struct Test2 {
+  template <typename U>
+  using type = typename TT<U>...[0]::template rebind<U>;
+};
+
+template <template<typename> typename... TT, typename U>
+auto test_unannotated() -> typename TT<U>...[0]::type;
+
+}


### PR DESCRIPTION
Previously, `ParseOptionalCXXScopeSpecifier` only handled pack-index-specifiers where the pattern was a simple identifier (e.g., `T...[0]::`). This patch adds support for `template-id` patterns (e.g., `Foo<T>...[0]::`).

The fix involves two parts:

1. Extend `ParsePackIndexingType` to handle `tok::annot_template_id` in addition to `tok::identifier`. 
2. Add handling inside the loop in `ParseOptionalCXXScopeSpecifier` for `annot_template_id` followed by `... [ constant-expression ]`.

This fixes code like:
```cpp
  template<template<class...> class... L> void f() {
    using T = mp_quote<L>...[0]::template fn<void>;
  }
```
which previously failed to parse.