### PR TITLE
[Clang][Sema] Fix crash when nested-name-specifier prefix points to non-dependent context

### DIFF
--- a/clang/lib/Sema/SemaCXXScopeSpec.cpp
+++ b/clang/lib/Sema/SemaCXXScopeSpec.cpp
@@ -33,7 +33,7 @@ static CXXRecordDecl *getCurrentInstantiationOf(QualType T,
     return nullptr;
   auto *RD = cast<CXXRecordDecl>(TagTy->getDecl())->getDefinitionOrSelf();
   if (isa<InjectedClassNameType>(TagTy) ||
-      RD->isCurrentInstantiation(CurContext))
+      (RD->isDependentContext() && RD->isCurrentInstantiation(CurContext)))
     return RD;
   return nullptr;
 }

--- a/clang/test/SemaTemplate/dependent-names.cpp
+++ b/clang/test/SemaTemplate/dependent-names.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 %s
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 -fms-extensions %s
 
 typedef double A;
 template<typename T> class B {
@@ -481,3 +482,17 @@ namespace TransformNestedName {
   template <typename T::template X<N<T>::State::kA>>
   inline void N<T>::F() {}
 } // namespace TransformNestedName
+
+namespace GH133610 {
+  struct a {
+    using e = int;
+  };
+
+#ifdef _MSC_EXTENSIONS
+  void current(const char * = __builtin_FUNCSIG());
+  template <class> void c() {
+    decltype(a(current()))::e;
+  }
+#endif
+}
+


### PR DESCRIPTION
After 154507c, a `NestedNameSpecifier` of `Type` kind can have a prefix pointing to a non-dependent type even when the NNS itself is dependent. This occurs when the `Type` has a prefix in its own qualified-id that refers to a non-dependent record.

The `getCurrentInstantiationOf()` function in `SemaCXXScopeSpec.cpp` would call `isCurrentInstantiation()` on such non-dependent records, triggering an assertion failure since `isCurrentInstantiation()` requires the record to be a dependent context.

This patch adds a guard to check `isDependentContext()` before calling `isCurrentInstantiation()`, matching the pattern used in all other call sites of `isCurrentInstantiation()` throughout the codebase.

Fixes 178324 in upstream.