### PR TITLE
[Clang][AST] Propagate error dependence for _Generic assoc types

### DIFF
--- a/clang/lib/AST/ComputeDependence.cpp
+++ b/clang/lib/AST/ComputeDependence.cpp
@@ -721,6 +721,9 @@ ExprDependence clang::computeDependence(GenericSelectionExpr *E,
                                   : ExprDependence::None;
   for (auto *AE : E->getAssocExprs())
     D |= AE->getDependence() & ExprDependence::Error;
+  for (auto *TSI : E->getAssocTypeSourceInfos())
+    if (TSI && TSI->getType()->containsErrors())
+      D |= ExprDependence::Error;
 
   if (E->isExprPredicate())
     D |= E->getControllingExpr()->getDependence() & ExprDependence::Error;

--- a/clang/test/Sema/generic-selection.c
+++ b/clang/test/Sema/generic-selection.c
@@ -44,6 +44,8 @@ int __attribute__((overloadable)) test (int);
 double __attribute__((overloadable)) test (double);
 char testc(char);
 
+int f(int);
+
 void PR30201(void) {
   _Generic(4, char:testc, default:test)(4); // ext-warning {{'_Generic' is a C11 extension}}
 }
@@ -86,3 +88,5 @@ void GH55562(void) {
   struct S s = { 0 };
   int i = s.a;
 }
+
+char *a = _Generic("", char (*)[f(x)]: ""); // expected-error {{use of undeclared identifier 'x'}} ext-warning {{'_Generic' is a C11 extension}}


### PR DESCRIPTION
The following input crashes:
```c
char *a = _Generic("", char (*)[f(x)]: "");
```

The crash is happens because a result-dependent `_Generic` ends up value-dependent without `ExprDependence::Error`, tripping the assertion in `CheckForConstantInitializer` in `SemaDecl.cpp`.

This patch propagates `ExprDependence::Error` from `_Generic` association types so result-dependent selections created during error recovery carry the error bit and avoid the constant-initializer assertion.

Fixes 176929 in upstream. 